### PR TITLE
선호도 조사: 영화 및 영화인 가져오기 API 구현

### DIFF
--- a/src/main/java/com/grilledsausage/molva/api/controller/content/ContentController.java
+++ b/src/main/java/com/grilledsausage/molva/api/controller/content/ContentController.java
@@ -1,5 +1,6 @@
 package com.grilledsausage.molva.api.controller.content;
 
+import com.grilledsausage.molva.api.dto.content.SurveyFilmmakerResponseDto;
 import com.grilledsausage.molva.api.dto.content.SurveyMovieResponseDto;
 import com.grilledsausage.molva.api.service.content.ContentService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,12 @@ public class ContentController {
     public List<SurveyMovieResponseDto> getSurveyMovieList() {
 
         return contentService.getSurveyMovieList();
+    }
+
+    @GetMapping("/survey/filmmaker")
+    public List<SurveyFilmmakerResponseDto> getSurveyFilmmakerList() {
+
+        return contentService.getSurveyFilmmakerList();
     }
 
 }

--- a/src/main/java/com/grilledsausage/molva/api/controller/content/ContentController.java
+++ b/src/main/java/com/grilledsausage/molva/api/controller/content/ContentController.java
@@ -1,0 +1,25 @@
+package com.grilledsausage.molva.api.controller.content;
+
+import com.grilledsausage.molva.api.dto.content.SurveyMovieResponseDto;
+import com.grilledsausage.molva.api.service.content.ContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/content")
+public class ContentController {
+
+    private final ContentService contentService;
+
+    @GetMapping("/survey/movie")
+    public List<SurveyMovieResponseDto> getSurveyMovieList() {
+
+        return contentService.getSurveyMovieList();
+    }
+
+}

--- a/src/main/java/com/grilledsausage/molva/api/controller/user/UserController.java
+++ b/src/main/java/com/grilledsausage/molva/api/controller/user/UserController.java
@@ -3,7 +3,7 @@ package com.grilledsausage.molva.api.controller.user;
 import com.grilledsausage.molva.api.dto.user.OAuthToken;
 import com.grilledsausage.molva.api.dto.user.UserInfoResponseDto;
 import com.grilledsausage.molva.api.entity.user.User;
-import com.grilledsausage.molva.api.service.UserService;
+import com.grilledsausage.molva.api.service.user.UserService;
 import com.grilledsausage.molva.config.JwtProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/com/grilledsausage/molva/api/dto/content/SurveyFilmmakerResponseDto.java
+++ b/src/main/java/com/grilledsausage/molva/api/dto/content/SurveyFilmmakerResponseDto.java
@@ -1,0 +1,41 @@
+package com.grilledsausage.molva.api.dto.content;
+
+import com.grilledsausage.molva.api.entity.filmmaker.Filmmaker;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class SurveyFilmmakerResponseDto {
+
+    private Long code;
+
+    private String name;
+
+    private String type;
+
+    private String image;
+
+    private Boolean isInSurvey;
+
+    @Builder
+    public SurveyFilmmakerResponseDto(Long code, String name, String type, String image, Boolean isInSurvey) {
+        this.code = code;
+        this.name = name;
+        this.type = type;
+        this.image = image;
+        this.isInSurvey = isInSurvey;
+    }
+
+    public static SurveyFilmmakerResponseDto from(Filmmaker filmmaker) {
+
+        return SurveyFilmmakerResponseDto
+                .builder()
+                .code(filmmaker.getCode())
+                .name(filmmaker.getName())
+                .type(filmmaker.getType())
+                .image(filmmaker.getImage())
+                .isInSurvey(filmmaker.getIsInSurvey())
+                .build();
+
+    }
+}

--- a/src/main/java/com/grilledsausage/molva/api/dto/content/SurveyMovieResponseDto.java
+++ b/src/main/java/com/grilledsausage/molva/api/dto/content/SurveyMovieResponseDto.java
@@ -1,0 +1,35 @@
+package com.grilledsausage.molva.api.dto.content;
+
+import com.grilledsausage.molva.api.entity.movie.Movie;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class SurveyMovieResponseDto {
+
+    Long id;
+
+    Long code;
+
+    String name;
+
+    String image;
+
+    @Builder
+    public SurveyMovieResponseDto(Long id, Long code, String name, String image) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+        this.image = image;
+    }
+
+    public static SurveyMovieResponseDto from(Movie movie) {
+        return SurveyMovieResponseDto
+                .builder()
+                .id(movie.getId())
+                .code(movie.getCode())
+                .name(movie.getName())
+                .image(movie.getImage())
+                .build();
+    }
+}

--- a/src/main/java/com/grilledsausage/molva/api/entity/filmmaker/Filmmaker.java
+++ b/src/main/java/com/grilledsausage/molva/api/entity/filmmaker/Filmmaker.java
@@ -2,6 +2,7 @@ package com.grilledsausage.molva.api.entity.filmmaker;
 
 import com.grilledsausage.molva.api.entity.participation.Participation;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,5 +35,14 @@ public class Filmmaker {
 
     @OneToMany(mappedBy = "filmmaker", fetch = FetchType.LAZY)
     private List<Participation> participations = new ArrayList<>();
+
+    @Builder
+    public Filmmaker(Long id, Long code, String name, String type, Boolean isInSurvey) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+        this.type = type;
+        this.isInSurvey = isInSurvey;
+    }
 
 }

--- a/src/main/java/com/grilledsausage/molva/api/entity/filmmaker/Filmmaker.java
+++ b/src/main/java/com/grilledsausage/molva/api/entity/filmmaker/Filmmaker.java
@@ -30,6 +30,9 @@ public class Filmmaker {
     @Column(name = "type", nullable = false)
     private String type;
 
+    @Column(name = "image", columnDefinition = "TEXT")
+    private String image;
+
     @Column(name = "is_in_survey", nullable = false)
     private Boolean isInSurvey;
 
@@ -37,11 +40,12 @@ public class Filmmaker {
     private List<Participation> participations = new ArrayList<>();
 
     @Builder
-    public Filmmaker(Long id, Long code, String name, String type, Boolean isInSurvey) {
+    public Filmmaker(Long id, Long code, String name, String type, String image, Boolean isInSurvey) {
         this.id = id;
         this.code = code;
         this.name = name;
         this.type = type;
+        this.image = image;
         this.isInSurvey = isInSurvey;
     }
 

--- a/src/main/java/com/grilledsausage/molva/api/entity/filmmaker/Filmmaker.java
+++ b/src/main/java/com/grilledsausage/molva/api/entity/filmmaker/Filmmaker.java
@@ -29,6 +29,9 @@ public class Filmmaker {
     @Column(name = "type", nullable = false)
     private String type;
 
+    @Column(name = "is_in_survey", nullable = false)
+    private Boolean isInSurvey;
+
     @OneToMany(mappedBy = "filmmaker", fetch = FetchType.LAZY)
     private List<Participation> participations = new ArrayList<>();
 

--- a/src/main/java/com/grilledsausage/molva/api/entity/filmmaker/FilmmakerRepository.java
+++ b/src/main/java/com/grilledsausage/molva/api/entity/filmmaker/FilmmakerRepository.java
@@ -2,6 +2,10 @@ package com.grilledsausage.molva.api.entity.filmmaker;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FilmmakerRepository extends JpaRepository<Filmmaker, Long> {
+
+    List<Filmmaker> findAllByIsInSurveyTrue();
 
 }

--- a/src/main/java/com/grilledsausage/molva/api/entity/movie/Movie.java
+++ b/src/main/java/com/grilledsausage/molva/api/entity/movie/Movie.java
@@ -54,6 +54,9 @@ public class Movie {
     @Column(name = "image", columnDefinition = "TEXT")
     private String image;
 
+    @Column(name = "is_in_survey", nullable = false)
+    private Boolean isInSurvey;
+
 //    양방향 조회가 필요할 때 추가하기
 //    @OneToMany(mappedBy = "movie", fetch = FetchType.LAZY)
 //    private List<Reservation> reservations = new ArrayList<Reservation>();

--- a/src/main/java/com/grilledsausage/molva/api/entity/movie/Movie.java
+++ b/src/main/java/com/grilledsausage/molva/api/entity/movie/Movie.java
@@ -68,7 +68,7 @@ public class Movie {
 //    private List<Participation> participations = new ArrayList<>();
 
     @Builder
-    public Movie(Long code, String name, String englishName, Long year, String nation, String genre, String genreList, Long runTime, Double naverRating, Double reviewRating, String story, String image) {
+    public Movie(Long code, String name, String englishName, Long year, String nation, String genre, String genreList, Long runTime, Double naverRating, Double reviewRating, String story, String image, Boolean isInSurvey) {
         this.code = code;
         this.name = name;
         this.englishName = englishName;
@@ -81,6 +81,7 @@ public class Movie {
         this.reviewRating = reviewRating;
         this.story = story;
         this.image = image;
+        this.isInSurvey = isInSurvey;
     }
 
 }

--- a/src/main/java/com/grilledsausage/molva/api/entity/movie/MovieRepository.java
+++ b/src/main/java/com/grilledsausage/molva/api/entity/movie/MovieRepository.java
@@ -2,6 +2,10 @@ package com.grilledsausage.molva.api.entity.movie;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MovieRepository extends JpaRepository<Movie, Long> {
+
+    List<Movie> findAllByIsInSurveyTrue();
 
 }

--- a/src/main/java/com/grilledsausage/molva/api/service/content/ContentService.java
+++ b/src/main/java/com/grilledsausage/molva/api/service/content/ContentService.java
@@ -1,0 +1,28 @@
+package com.grilledsausage.molva.api.service.content;
+
+import com.grilledsausage.molva.api.dto.content.SurveyMovieResponseDto;
+import com.grilledsausage.molva.api.entity.filmmaker.FilmmakerRepository;
+import com.grilledsausage.molva.api.entity.movie.Movie;
+import com.grilledsausage.molva.api.entity.movie.MovieRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class ContentService {
+
+    private final MovieRepository movieRepository;
+
+    private final FilmmakerRepository filmmakerRepository;
+
+    public List<SurveyMovieResponseDto> getSurveyMovieList() {
+
+        List<Movie> movieList = movieRepository.findAllByIsInSurveyTrue();
+
+        return movieList.stream().map(SurveyMovieResponseDto::from).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/grilledsausage/molva/api/service/content/ContentService.java
+++ b/src/main/java/com/grilledsausage/molva/api/service/content/ContentService.java
@@ -1,6 +1,8 @@
 package com.grilledsausage.molva.api.service.content;
 
+import com.grilledsausage.molva.api.dto.content.SurveyFilmmakerResponseDto;
 import com.grilledsausage.molva.api.dto.content.SurveyMovieResponseDto;
+import com.grilledsausage.molva.api.entity.filmmaker.Filmmaker;
 import com.grilledsausage.molva.api.entity.filmmaker.FilmmakerRepository;
 import com.grilledsausage.molva.api.entity.movie.Movie;
 import com.grilledsausage.molva.api.entity.movie.MovieRepository;
@@ -23,6 +25,15 @@ public class ContentService {
         List<Movie> movieList = movieRepository.findAllByIsInSurveyTrue();
 
         return movieList.stream().map(SurveyMovieResponseDto::from).collect(Collectors.toList());
+
+    }
+
+    public List<SurveyFilmmakerResponseDto> getSurveyFilmmakerList() {
+
+        List<Filmmaker> filmmakerList = filmmakerRepository.findAllByIsInSurveyTrue();
+
+        return filmmakerList.stream().map(SurveyFilmmakerResponseDto::from).collect(Collectors.toList());
+
     }
 
 }

--- a/src/main/java/com/grilledsausage/molva/api/service/user/UserService.java
+++ b/src/main/java/com/grilledsausage/molva/api/service/user/UserService.java
@@ -1,4 +1,4 @@
-package com.grilledsausage.molva.api.service;
+package com.grilledsausage.molva.api.service.user;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;

--- a/src/main/java/com/grilledsausage/molva/config/InitDatabaseForLocal.java
+++ b/src/main/java/com/grilledsausage/molva/config/InitDatabaseForLocal.java
@@ -55,24 +55,6 @@ public class InitDatabaseForLocal {
             user2.setNickname("say_hi");
             userRepository.save(user2);
 
-
-//            20228230,요정,Fairy,2022,한국,드라마,드라마,79
-//            20224755,나는 마을 방과후 교사입니다,"The Teachers: pink, nature trail, ridge between rice paddies, plum",2022,한국,다큐멘터리,다큐멘터리,94
-//            20228915,사랑하는 당신에게,Last Dance,2022,스위스,드라마,드라마,82
-//            20196478,영웅,Hero,2022,한국,드라마,"드라마,뮤지컬",120
-//            20229052,러브 플랫폼,The moment fall in love,2022,한국,드라마,드라마,
-//                    19978205,암화,The Longest Nite,1997,홍콩,범죄,"범죄,스릴러",82
-//            20228895,캐리와 슈퍼콜라,CARRIE&SUPERKOLA,2022,한국,애니메이션,애니메이션,79
-//            20193581,감각의 제국 감독판,In the Realm of the Senses,1976,프랑스,드라마,"드라마,성인물(에로)",101
-//            20228612,팬픽에서 연애까지,,2022,한국,멜로/로맨스,"멜로/로맨스,코미디",89
-//            20204264,콘크리트 유토피아,,2021,한국,스릴러,스릴러,
-//                    20226411,범죄도시3,THE ROUNDUP : NO WAY OUT,2022,한국,범죄,"범죄,액션",
-//                    20229059,슬로우,Slow,2021,한국,드라마,드라마,3
-//            20229049,"다시, 만남",MEET AGAIN,2022,한국,드라마,드라마,3
-//            20229058,미스터 플라스틱의 하루,A Day of Mr. Plastic,2022,한국,애니메이션,애니메이션,2
-//            20204548,범죄도시2,The Roundup,2022,한국,범죄,"범죄,액션",105
-//            20229048,엄마의 산책,A comfortable moments,2022,한국,드라마,드라마,1
-
             Movie movie1 = Movie
                     .builder()
                     .code(20228230L)
@@ -117,6 +99,36 @@ public class InitDatabaseForLocal {
                     .build();
 
             movieRepository.save(movie3);
+//
+//            Filmmaker filmmaker1 = Filmmaker
+//                    .builder()
+//                    .code(1L)
+//                    .name("김민근")
+//                    .type("배우")
+//                    .isInSurvey(true)
+//                    .build();
+//
+//            filmmakerRepository.save(filmmaker1);
+//
+//            Filmmaker filmmaker2 = Filmmaker
+//                    .builder()
+//                    .code(2L)
+//                    .name("윤석민")
+//                    .type("감독")
+//                    .isInSurvey(true)
+//                    .build();
+//
+//            filmmakerRepository.save(filmmaker2);
+//
+//            Filmmaker filmmaker3 = Filmmaker
+//                    .builder()
+//                    .code(3L)
+//                    .name("박동진")
+//                    .type("배우")
+//                    .isInSurvey(false)
+//                    .build();
+//
+//            filmmakerRepository.save(filmmaker3);
         }
 
     }

--- a/src/main/java/com/grilledsausage/molva/config/InitDatabaseForLocal.java
+++ b/src/main/java/com/grilledsausage/molva/config/InitDatabaseForLocal.java
@@ -1,5 +1,8 @@
 package com.grilledsausage.molva.config;
 
+import com.grilledsausage.molva.api.entity.filmmaker.FilmmakerRepository;
+import com.grilledsausage.molva.api.entity.movie.Movie;
+import com.grilledsausage.molva.api.entity.movie.MovieRepository;
 import com.grilledsausage.molva.api.entity.user.User;
 import com.grilledsausage.molva.api.entity.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,10 @@ public class InitDatabaseForLocal {
 
         private final UserRepository userRepository;
 
+        private final MovieRepository movieRepository;
+
+        private final FilmmakerRepository filmmakerRepository;
+
         @Transactional
         public void init() {
 
@@ -48,6 +55,68 @@ public class InitDatabaseForLocal {
             user2.setNickname("say_hi");
             userRepository.save(user2);
 
+
+//            20228230,요정,Fairy,2022,한국,드라마,드라마,79
+//            20224755,나는 마을 방과후 교사입니다,"The Teachers: pink, nature trail, ridge between rice paddies, plum",2022,한국,다큐멘터리,다큐멘터리,94
+//            20228915,사랑하는 당신에게,Last Dance,2022,스위스,드라마,드라마,82
+//            20196478,영웅,Hero,2022,한국,드라마,"드라마,뮤지컬",120
+//            20229052,러브 플랫폼,The moment fall in love,2022,한국,드라마,드라마,
+//                    19978205,암화,The Longest Nite,1997,홍콩,범죄,"범죄,스릴러",82
+//            20228895,캐리와 슈퍼콜라,CARRIE&SUPERKOLA,2022,한국,애니메이션,애니메이션,79
+//            20193581,감각의 제국 감독판,In the Realm of the Senses,1976,프랑스,드라마,"드라마,성인물(에로)",101
+//            20228612,팬픽에서 연애까지,,2022,한국,멜로/로맨스,"멜로/로맨스,코미디",89
+//            20204264,콘크리트 유토피아,,2021,한국,스릴러,스릴러,
+//                    20226411,범죄도시3,THE ROUNDUP : NO WAY OUT,2022,한국,범죄,"범죄,액션",
+//                    20229059,슬로우,Slow,2021,한국,드라마,드라마,3
+//            20229049,"다시, 만남",MEET AGAIN,2022,한국,드라마,드라마,3
+//            20229058,미스터 플라스틱의 하루,A Day of Mr. Plastic,2022,한국,애니메이션,애니메이션,2
+//            20204548,범죄도시2,The Roundup,2022,한국,범죄,"범죄,액션",105
+//            20229048,엄마의 산책,A comfortable moments,2022,한국,드라마,드라마,1
+
+            Movie movie1 = Movie
+                    .builder()
+                    .code(20228230L)
+                    .name("요정")
+                    .englishName("Fairy")
+                    .year(2022L)
+                    .nation("한국")
+                    .genre("드라마")
+                    .genreList("드라마")
+                    .runTime(79L)
+                    .isInSurvey(true)
+                    .build();
+
+            movieRepository.save(movie1);
+
+            Movie movie2 = Movie
+                    .builder()
+                    .code(20224755L)
+                    .name("나는 마을 방과후 교사입니다")
+                    .englishName("The Teachers: pink, nature trail, ridge between rice paddies, plum")
+                    .year(2022L)
+                    .nation("한국")
+                    .genre("다큐멘터리")
+                    .genreList("다큐멘터리")
+                    .runTime(94L)
+                    .isInSurvey(true)
+                    .build();
+
+            movieRepository.save(movie2);
+
+            Movie movie3 = Movie
+                    .builder()
+                    .code(20228915L)
+                    .name("사랑하는 당신에게")
+                    .englishName("Last Dance")
+                    .year(2022L)
+                    .nation("스위스")
+                    .genre("드라마")
+                    .genreList("드라마")
+                    .runTime(82L)
+                    .isInSurvey(false)
+                    .build();
+
+            movieRepository.save(movie3);
         }
 
     }

--- a/src/main/java/com/grilledsausage/molva/config/InitDatabaseForLocal.java
+++ b/src/main/java/com/grilledsausage/molva/config/InitDatabaseForLocal.java
@@ -1,5 +1,6 @@
 package com.grilledsausage.molva.config;
 
+import com.grilledsausage.molva.api.entity.filmmaker.Filmmaker;
 import com.grilledsausage.molva.api.entity.filmmaker.FilmmakerRepository;
 import com.grilledsausage.molva.api.entity.movie.Movie;
 import com.grilledsausage.molva.api.entity.movie.MovieRepository;
@@ -99,36 +100,36 @@ public class InitDatabaseForLocal {
                     .build();
 
             movieRepository.save(movie3);
-//
-//            Filmmaker filmmaker1 = Filmmaker
-//                    .builder()
-//                    .code(1L)
-//                    .name("김민근")
-//                    .type("배우")
-//                    .isInSurvey(true)
-//                    .build();
-//
-//            filmmakerRepository.save(filmmaker1);
-//
-//            Filmmaker filmmaker2 = Filmmaker
-//                    .builder()
-//                    .code(2L)
-//                    .name("윤석민")
-//                    .type("감독")
-//                    .isInSurvey(true)
-//                    .build();
-//
-//            filmmakerRepository.save(filmmaker2);
-//
-//            Filmmaker filmmaker3 = Filmmaker
-//                    .builder()
-//                    .code(3L)
-//                    .name("박동진")
-//                    .type("배우")
-//                    .isInSurvey(false)
-//                    .build();
-//
-//            filmmakerRepository.save(filmmaker3);
+
+            Filmmaker filmmaker1 = Filmmaker
+                    .builder()
+                    .code(1L)
+                    .name("김민근")
+                    .type("배우")
+                    .isInSurvey(true)
+                    .build();
+
+            filmmakerRepository.save(filmmaker1);
+
+            Filmmaker filmmaker2 = Filmmaker
+                    .builder()
+                    .code(2L)
+                    .name("윤석민")
+                    .type("감독")
+                    .isInSurvey(true)
+                    .build();
+
+            filmmakerRepository.save(filmmaker2);
+
+            Filmmaker filmmaker3 = Filmmaker
+                    .builder()
+                    .code(3L)
+                    .name("박동진")
+                    .type("배우")
+                    .isInSurvey(false)
+                    .build();
+
+            filmmakerRepository.save(filmmaker3);
         }
 
     }

--- a/src/main/java/com/grilledsausage/molva/config/JwtProperties.java
+++ b/src/main/java/com/grilledsausage/molva/config/JwtProperties.java
@@ -1,11 +1,18 @@
 package com.grilledsausage.molva.config;
 
-public interface JwtProperties {
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
-    int EXPIRATION_TIME = 864000000;
+@Component
+public class JwtProperties {
 
-    String TOKEN_PREFIX = "Bearer ";
+    public static final int EXPIRATION_TIME = 864000000;
 
-    String HEADER_STRING = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    public static final String HEADER_STRING = "Authorization";
+
+    @Value("${jwt.secret}")
+    public String SECRET;
 
 }

--- a/src/main/java/com/grilledsausage/molva/config/JwtRequestFilter.java
+++ b/src/main/java/com/grilledsausage/molva/config/JwtRequestFilter.java
@@ -9,7 +9,6 @@ import com.grilledsausage.molva.api.service.user.UserService;
 import com.grilledsausage.molva.exception.custom.InvalidJwtTokenException;
 import com.grilledsausage.molva.exception.custom.NoJwtTokenException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,10 +23,8 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtRequestFilter extends OncePerRequestFilter {
 
+    private final JwtProperties jwtProperties;
     private final UserService userService;
-
-    @Value("${jwt.secret}")
-    private String JWT_SECRET;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -46,7 +43,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         String email = null;
 
         try {
-            email = JWT.require(Algorithm.HMAC512(JWT_SECRET)).build().verify(token)
+            email = JWT.require(Algorithm.HMAC512(jwtProperties.SECRET)).build().verify(token)
                     .getClaim("email").asString();
 
         } catch (TokenExpiredException e) {

--- a/src/main/java/com/grilledsausage/molva/config/JwtRequestFilter.java
+++ b/src/main/java/com/grilledsausage/molva/config/JwtRequestFilter.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -23,7 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @RequiredArgsConstructor
-@Component
 public class JwtRequestFilter extends OncePerRequestFilter {
 
     private final UserService userService;

--- a/src/main/java/com/grilledsausage/molva/config/JwtRequestFilter.java
+++ b/src/main/java/com/grilledsausage/molva/config/JwtRequestFilter.java
@@ -5,7 +5,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.grilledsausage.molva.api.entity.user.User;
-import com.grilledsausage.molva.api.service.UserService;
+import com.grilledsausage.molva.api.service.user.UserService;
 import com.grilledsausage.molva.exception.custom.InvalidJwtTokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/grilledsausage/molva/config/JwtRequestFilter.java
+++ b/src/main/java/com/grilledsausage/molva/config/JwtRequestFilter.java
@@ -7,6 +7,7 @@ import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.grilledsausage.molva.api.entity.user.User;
 import com.grilledsausage.molva.api.service.user.UserService;
 import com.grilledsausage.molva.exception.custom.InvalidJwtTokenException;
+import com.grilledsausage.molva.exception.custom.NoJwtTokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -36,8 +37,10 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         String jwtHeader = request.getHeader(JwtProperties.HEADER_STRING);
 
         if (jwtHeader == null || !jwtHeader.startsWith(JwtProperties.TOKEN_PREFIX)) {
-            filterChain.doFilter(request, response);
-            return;
+            throw NoJwtTokenException.builder()
+                    .httpStatus(HttpStatus.FORBIDDEN)
+                    .message("JWT가 HTTP 헤더에 존재하지 않습니다.")
+                    .build();
         }
 
         String token = jwtHeader.replace(JwtProperties.TOKEN_PREFIX, "");

--- a/src/main/java/com/grilledsausage/molva/config/SecurityConfig.java
+++ b/src/main/java/com/grilledsausage/molva/config/SecurityConfig.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final JwtProperties jwtProperties;
     private final UserService userService;
 
     @Bean
@@ -30,7 +31,8 @@ public class SecurityConfig {
         return web -> {
             web.ignoring().antMatchers(
                     "/swagger-ui.html",
-                    "/h2-console/**"
+                    "/h2-console/**",
+                    "/api/auth/token"
             );
         };
 
@@ -53,7 +55,7 @@ public class SecurityConfig {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .addFilterBefore(new JwtRequestFilter(userService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtRequestFilter(jwtProperties, userService), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtRequestFilter.class)
 //                 .exceptionHandling()
 //                 .authenticationEntryPoint()

--- a/src/main/java/com/grilledsausage/molva/config/SecurityConfig.java
+++ b/src/main/java/com/grilledsausage/molva/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.grilledsausage.molva.config;
 
+import com.grilledsausage.molva.api.service.user.UserService;
 import com.grilledsausage.molva.exception.ExceptionHandlerFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,9 +22,7 @@ import java.util.Arrays;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JwtRequestFilter jwtRequestFilter;
-
-    private final ExceptionHandlerFilter exceptionHandlerFilter;
+    private final UserService userService;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -54,8 +53,8 @@ public class SecurityConfig {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(exceptionHandlerFilter, JwtRequestFilter.class)
+                .addFilterBefore(new JwtRequestFilter(userService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new ExceptionHandlerFilter(), JwtRequestFilter.class)
 //                 .exceptionHandling()
 //                 .authenticationEntryPoint()
 //                 .accessDeniedHandler()

--- a/src/main/java/com/grilledsausage/molva/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/grilledsausage/molva/exception/ExceptionHandlerFilter.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.grilledsausage.molva.exception.custom.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -18,7 +17,6 @@ import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Slf4j
-@Component
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
     @Override

--- a/src/main/java/com/grilledsausage/molva/exception/custom/NoJwtTokenException.java
+++ b/src/main/java/com/grilledsausage/molva/exception/custom/NoJwtTokenException.java
@@ -1,0 +1,15 @@
+package com.grilledsausage.molva.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class NoJwtTokenException extends CustomException {
+
+    public NoJwtTokenException(String message) {
+        super(message);
+    }
+
+    public NoJwtTokenException(HttpStatus httpStatus, String message) {
+        super(httpStatus, message);
+    }
+
+}


### PR DESCRIPTION
1. 선호도 조사용 영화 가져오기 API 구현
2. 선호도 조사용 영화인 가져오기 API 구현
3. 영화, 영화인 Entity에 선호도 조사 포함 여부를 판단하는 컬럼 추가
4. Custom Filter를 등록할 때 Bean이 아니라 생성자를 통해 등록하도록 수정
5. jwt.secret을 JwtProperties에서 가져오도록 수정